### PR TITLE
Add a basic Logging class

### DIFF
--- a/reframework/autorun/randomizer.lua
+++ b/reframework/autorun/randomizer.lua
@@ -21,6 +21,7 @@ Helpers = require("randomizer/Helpers")
 Inventory = require("randomizer/Inventory")
 ItemBox = require("randomizer/ItemBox")
 Items = require("randomizer/Items")
+Logging = require("randomizer/Logging")
 Player = require("randomizer/Player")
 Scene = require("randomizer/Scene")
 StartingWeapon = require("randomizer/StartingWeapon")
@@ -30,7 +31,7 @@ Tools = require("randomizer/Tools")
 -- END globals
 
 Lookups.Load("Ethan", "a" ,"normal")
-
+Logging.Init()
 
 -- For debugging / trying out functionality:
 -- Player.GetInventorySlots()
@@ -113,3 +114,4 @@ re.on_draw_ui(function () -- this is only called when Script Generated UI is vis
 end)
 
 log.debug("[Randomizer] Mod loaded.")
+

--- a/reframework/autorun/randomizer/Logging.lua
+++ b/reframework/autorun/randomizer/Logging.lua
@@ -1,0 +1,21 @@
+local Logging = {}
+
+Logging.filepath = "./"
+Logging.filename = nil
+
+function Logging.Init()
+    Logging.filename = Logging.filepath .. "logs-" .. os.date("%Y-%m-%d-%H%M%S") .. ".txt"
+end
+
+function Logging.Log(message)
+    existing_log_data = fs.read(Logging.filename) or ""
+
+    if existing_log_data ~= "" then
+        existing_log_data = existing_log_data .. "\n"
+    end
+
+    fs.write(Logging.filename, existing_log_data .. tostring(message))
+end
+
+return Logging
+


### PR DESCRIPTION
Saw that you mentioned that logging large pieces of data to the console can crash the game sometimes. Had a few moments in between things today and figured I'd write this logging alternative that writes to a file instead.

To use it, you'd just do something like:
`Logging.Log(whatever)`

`whatever` can be a string, object, etc.

Log files are written to the `reframework/data` folder.